### PR TITLE
Add local website development script

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -61,6 +61,19 @@ DataScienceKansasCity.github.io/
 3. **Run the development server**
 
    ```bash
+   ./serve-local.sh
+   ```
+
+   This runs `hugo server -D` with local defaults and serves the site at `http://localhost:1313`.
+   You can still pass through Hugo flags when needed:
+
+   ```bash
+   ./serve-local.sh --disableFastRender
+   ```
+
+   The raw Hugo command is also supported:
+
+   ```bash
    hugo server -D
    ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,11 @@ We welcome various types of contributions:
    - Run the development server:
 
      ```bash
-     hugo server -D
+     ./serve-local.sh
      ```
+
+     This wraps `hugo server -D` with local defaults and hosts the site at `http://localhost:1313`.
+     You can also run `hugo server -D` directly.
 
 3. **Create a feature branch**
 
@@ -149,6 +152,9 @@ We welcome various types of contributions:
 hugo --minify
 
 # Run the development server
+./serve-local.sh
+
+# Or run Hugo directly
 hugo server -D
 
 # Check for build errors

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "description": "E2E tests for Data Science Kansas City website",
   "scripts": {
+    "dev": "./serve-local.sh",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:ui": "playwright test --ui",

--- a/serve-local.sh
+++ b/serve-local.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-1313}"
+BASE_URL="${BASE_URL:-http://localhost:${PORT}/}"
+
+if ! command -v hugo >/dev/null 2>&1; then
+  echo "Error: hugo is not installed or is not on PATH." >&2
+  echo "Install Hugo: https://gohugo.io/installation/" >&2
+  exit 1
+fi
+
+echo "Serving Data Science Kansas City at ${BASE_URL}"
+echo "Press Ctrl+C to stop the server."
+
+exec hugo server \
+  --buildDrafts \
+  --bind "${HOST}" \
+  --baseURL "${BASE_URL}" \
+  --port "${PORT}" \
+  "$@"


### PR DESCRIPTION
## Summary

Adds a local development command for serving the Hugo site.

- Adds `serve-local.sh` to run `hugo server -D` with local defaults.
- Documents `./serve-local.sh` as the recommended command, with raw `hugo server -D` as an alternative.

## Validation

- Ran `./serve-local.sh --disableFastRender` and confirmed Hugo served the site successfully.
- Pre-commit hooks passed while committing.
