### PR TITLE
Announce the 2026-2027 event season

### DIFF
--- a/content/posts/2026-08-21-save-the-dates-2026-2027.md
+++ b/content/posts/2026-08-21-save-the-dates-2026-2027.md
@@ -1,0 +1,62 @@
+---
+title: "Save the Dates: Data Science KC's 2026-2027 Season"
+description: "Mark your calendar for ten Data Science KC events from September 2026 through June 2027."
+date: 2026-08-21
+lastmod: 2026-08-21
+aliases:
+  - "/2026-2027-events/"
+categories: ["events", "announcements"]
+tags: ["data science", "kansas city", "meetup"]
+---
+
+**A new season of Data Science KC events is about to begin. Join us as we learn, share, and connect.**
+
+Whether you want to explore how data and AI are being applied inside real organizations, see what Kansas City's students and startups are building, share your own work, or simply meet other people in the community with an interest in data, there is something for you in this season's lineup.
+
+Below is a tentative schedule for our upcoming year. Each event will be announced through Meetup with time and location.
+
+## 📅 2026-2027 Tentative Schedule
+
+| Date | Event |
+| --- | --- |
+| **September 10, 2026** | [A Multi-Agent System for Finding In-Demand Skills Across a 21k-Member Enterprise](https://www.meetup.com/data-science-kc/events/316119292/) |
+| **October 8, 2026** | Topic to be announced |
+| **November 12, 2026** | University Showcase |
+| **December 10, 2026** | Topic to be announced |
+| **January 14, 2027** | Topic to be announced |
+| **February 11, 2027** | Topic to be announced |
+| **March 11, 2027** | Topic to be announced |
+| **April 8, 2027** | Topic to be announced |
+| **May 13, 2027** | Startup Showcase |
+| **June 10, 2027** | Summer Social |
+
+## 🤖 First Up: Multi-Agent Systems at Enterprise Scale
+
+We will kick off the season on **Thursday, September 10** with **A Multi-Agent System for Finding In-Demand Skills Across a 21k-Member Enterprise**. Join us for a practical look at how a multi-agent system can address a real challenge at enterprise scale.
+
+<span style="font-size:1.4em;">[**RSVP for the September event on Meetup**](https://www.meetup.com/data-science-kc/events/316119292/)</span>
+
+## 🌟 Showcases and Community Favorites
+
+Our annual showcases will return this season. We'll share details on location and how to sign up as we get closer.
+
+- The **University Showcase** on November 12 gives students and recent graduates an opportunity to share projects and research with Kansas City's data community. We'll share more information on how to sign up soon.
+- The **Startup Showcase** on May 13 brings together local founders and practitioners to show how startups are using data to build products, improve operations, and grow their businesses.
+
+We plan to close the season with our annual **Summer Social** on June 10, a relaxed evening focused on conversation and new connections.
+
+Programs for the remaining monthly events are still taking shape. We will announce speakers, topics, locations, and RSVP details on [Meetup](/meetup) as each event approaches.
+
+## 🤝 Thank You to Our Partners and Sponsors
+
+Thank you to our partners at [KC Digital Drive](https://www.kcdigitaldrive.org/) for supporting our community and helping us bring people together throughout the year. We are also grateful to [Keystone CoLAB](https://www.keystonedistrict.org/colab) for providing space for many of our events, and to all of our event sponsors for the refreshments and resources that make these gatherings possible. Your investment in Kansas City's data community helps it continue to grow.
+
+## 🎤 Help Shape the Season
+
+Data Science KC is built by people who are willing to share what they have learned. If you have a project, case study, technical deep dive, hard-earned lesson, or discussion idea that would benefit the community, we would love to hear from you.
+
+- **Email:** [dskc.group@gmail.com](mailto:dskc.group@gmail.com)
+- **Slack:** [Join the Data Science KC Slack](/slack)
+- **Meetup:** [Follow Data Science KC on Meetup](/meetup)
+
+Save the dates, invite a colleague, and join us for another season of learning and community in Kansas City. We look forward to seeing you!

--- a/tests/e2e/home-and-nav.spec.ts
+++ b/tests/e2e/home-and-nav.spec.ts
@@ -47,6 +47,13 @@ test("home nav link from posts returns to home page", async ({ page }) => {
   await expect(page).toHaveURL("/");
 });
 
+test("2026-2027 event schedule post loads", async ({ page }) => {
+  await page.goto("/posts/2026-08-21-save-the-dates-2026-2027/");
+  await expect(page).toHaveTitle(/Save the Dates: Data Science KC's 2026-2027 Season/i);
+  await expect(page.getByRole("heading", { name: "2026-2027 Tentative Schedule" })).toBeVisible();
+  await expect(page.getByRole("link", { name: /RSVP for the September event/i })).toBeVisible();
+});
+
 test("call for speakers post loads", async ({ page }) => {
   await page.goto("/posts/2026-02-22-startup-showcase/");
   await expect(page).toHaveTitle(/Call for Speakers: Startup Showcase \(May 14, 2026\)/i);


### PR DESCRIPTION
## Summary

Publishes the tentative September 2026 through June 2027 event schedule, highlights the September kickoff and annual showcases, and thanks KC Digital Drive, Keystone CoLAB, and event sponsors.