### PR TITLE
Hide expired announcements from the homepage

### DIFF
--- a/content/posts/2026-08-21-save-the-dates-2026-2027.md
+++ b/content/posts/2026-08-21-save-the-dates-2026-2027.md
@@ -3,6 +3,7 @@ title: "Save the Dates: Data Science KC's 2026-2027 Season"
 description: "Mark your calendar for ten Data Science KC events from September 2026 through June 2027."
 date: 2026-08-21
 lastmod: 2026-08-21
+hide-from-front-page-after-date: "2026-11-01"
 aliases:
   - "/2026-2027-events/"
 categories: ["events", "announcements"]

--- a/layouts/partials/home/page.html
+++ b/layouts/partials/home/page.html
@@ -70,7 +70,20 @@
 
 {{ $recentPosts := where .Site.RegularPages "Type" "in" .Site.Params.mainSections }}
 {{ $recentPosts = $recentPosts.ByDate.Reverse }}
-{{ if or (gt (len $upcomingEvents) 0) (gt (len $recentPosts) 0) }}
+{{ $announcementPosts := first 1 $recentPosts }}
+{{ $pinnedPosts := where $recentPosts "Params.pinHome" true }}
+{{ if gt (len $pinnedPosts) 0 }}
+  {{ $announcementPosts = first 1 $pinnedPosts.ByDate.Reverse }}
+{{ end }}
+{{ $showAnnouncement := gt (len $announcementPosts) 0 }}
+{{ if $showAnnouncement }}
+  {{ $announcementPost := index $announcementPosts 0 }}
+  {{ with index $announcementPost.Params "hide-from-front-page-after-date" }}
+    {{ $hideAfter := (time.AsTime . "America/Chicago").AddDate 0 0 1 }}
+    {{ $showAnnouncement = now.Before $hideAfter }}
+  {{ end }}
+{{ end }}
+{{ if or (gt (len $upcomingEvents) 0) $showAnnouncement }}
   <section class="mt-6 mb-12 grid grid-cols-1 sm:grid-cols-2 gap-3">
     {{ if gt (len $upcomingEvents) 0 }}
       {{ $nextEvent := index $upcomingEvents 0 }}
@@ -94,12 +107,8 @@
       </div>
     {{ end }}
 
-    {{ if gt (len $recentPosts) 0 }}
-      {{ $announcementPost := index $recentPosts 0 }}
-      {{ $pinnedPosts := where $recentPosts "Params.pinHome" true }}
-      {{ if gt (len $pinnedPosts) 0 }}
-        {{ $announcementPost = index ($pinnedPosts.ByDate.Reverse) 0 }}
-      {{ end }}
+    {{ if $showAnnouncement }}
+      {{ $announcementPost := index $announcementPosts 0 }}
       <div class="flex flex-col">
         <h2 class="m-0 mb-2 text-sm font-semibold uppercase tracking-wide text-primary-700 dark:text-neutral-200">Announcements</h2>
         <div class="h-full flex flex-col rounded-lg border border-primary-500 p-4 sm:p-5 bg-neutral-50 dark:bg-neutral-800/60">

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,12 +13,21 @@ export default defineConfig({
     screenshot: "only-on-failure",
     video: "retain-on-failure"
   },
-  webServer: {
-    command: "hugo server -D --bind 127.0.0.1 --port 1313 --baseURL http://127.0.0.1:1313 --disableFastRender",
-    url: "http://127.0.0.1:1313",
-    reuseExistingServer: !process.env.CI,
-    timeout: 120000
-  },
+  webServer: [
+    {
+      command: "hugo server -D --renderToMemory --bind 127.0.0.1 --port 1313 --baseURL http://127.0.0.1:1313 --disableFastRender",
+      url: "http://127.0.0.1:1313",
+      reuseExistingServer: !process.env.CI,
+      timeout: 120000
+    },
+    {
+      command:
+        "hugo server -D --renderToMemory --clock 2038-01-01T00:00:00-06:00 --bind 127.0.0.1 --port 1314 --baseURL http://127.0.0.1:1314 --disableFastRender",
+      url: "http://127.0.0.1:1314",
+      reuseExistingServer: !process.env.CI,
+      timeout: 120000
+    }
+  ],
   projects: [
     {
       name: "chromium",

--- a/tests/e2e/home-and-nav.spec.ts
+++ b/tests/e2e/home-and-nav.spec.ts
@@ -14,6 +14,15 @@ test("home page smoke test", async ({ page }) => {
   await expect(page.locator('iframe[src*="youtube.com"]')).toBeAttached();
 });
 
+test("expired announcement is hidden from the home page", async ({ page }) => {
+  await page.goto("http://127.0.0.1:1314/");
+
+  await expect(
+    page.getByText("Connecting, Learning, and Growing Together in the Heart of America")
+  ).toBeVisible();
+  await expect(page.getByRole("heading", { level: 2, name: "Announcements" })).toHaveCount(0);
+});
+
 test("mobile nav opens, shows links, and closes", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/");


### PR DESCRIPTION
## Summary

Adds an optional `hide-from-front-page-after-date` post parameter and hides the homepage announcement card after that date while keeping the post published elsewhere. The 2026-2027 season announcement remains featured through November 1, 2026.